### PR TITLE
Host codeacross.ca website on GitHub Pages

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+codeacross.ca


### PR DESCRIPTION
If we decide that we want to go this route and host the CodeAcross website on GitHub Pages, here are the steps that must be taken.


- [x] merge this PR
  - the GitHub Pages site will then start redirecting to codeacross.ca, but still no effect on prior website and domain
- [x] Follow these official docs for ["setting up an apex domain"](https://help.github.com/articles/setting-up-an-apex-domain-and-www-subdomain/)
  - this is the step that will change DNS pointers from our prior host to GitHub Pages
- [ ] View GitHub-hosted website at [codeacross.ca](http://codeacross.ca)
- [ ] Update repo and readme descriptions to indicate that this is actual codebase now.