### PR TITLE
Adapt CONTRIBUTING.md to have a non-GitHub approach

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,45 +3,74 @@
 Hey there! Glad that you're interested in contributing! We really
 appreciate it. :tada:
 
-## Background
+We know that skills and expertise can vary greatly, so we organize this
+resource by the type of contributor you are. Please **follow the path that
+best describes you**:
+
+* [I'm moderately technical, and interested in working openly on
+  GitHub.][audience-technical]
+* [I don't have time to learn GitHub, but would love for someone to help me
+  make a change.][audience-no-github]
+
+## Contributing via GitHub
+
+### Background
+
+For a quick summary of technologies used, see the [README][tech-used].
 
 Here are the quick and dirty details that you should know about how we
 work.
 
-* We share push access liberally. (Just ask!)
+* We share push access liberally. (Just [open an issue][new-issue] and ask!)
 * `master` branch is automatically deployed to our live website.
 * `master` branch is protected, and so can't be pushed to directly.
 * All changes are made through pull requests.
 
-## Contributing
+### Step-by-Step
 
 Here are the general steps that we recommend you follow to get your
-great improvements onto the website:
+improvements onto the website:
 
 1. **Before doing any work, open a new issue** to discuss your idea.
    This helps ensure that our visions align. We'd hate for you to do
    work that we then couldn't merge!
 2. Ask for push access. (We'll give it to you!)
-  * We use branch protection on `master`, so you can't push there.
+    * We use branch protection on `master`, so you can't push there.
 3. **Create a "topic branch"** in the main repo, describing your change. eg.
    `my-special-feature`.
 4. Make some commits.
 5. As early as you'd like, **create a "pull request"** for your branch into
    `master`.
-  * If your branch is in the main repo, you'll notice that a review app
-    will deployed with your code, and linked in the issue. This will
-    help us collaborate more smoothly.
+    * If your branch is in the main repo, you'll notice that a review app
+      will deployed with your code, and linked in the issue. This will
+      help us collaborate more smoothly.
 6. When you think your changes are ready, post a pull request comment to
    say so, and **ask for a review**.
 7. **We'll review your changes** with the help of the Review App. Then we'll either:
-  1. merge them right away, or
-  2. ask you to make some changes.
-    - Don't worry! This is totally no big deal! Working together to get
-      things just right is a common dynamic in contributing to projects.
-      We'll work together on it!
+    1. merge them right away, or
+    2. ask you to make some changes.
+        - Don't worry! This is totally no big deal! Working together to get
+          things just right is a common dynamic in contributing to projects.
+          We'll work on it together.
 8. After coming to agreement on the best possible contribution, **we'll
    merge your changes** into `master`!
 9. Your changes are now live on the website. Yay! Thanks a bunch!
 
+## Contributing without GitHub
+
+We totally get it: GitHub can be intimidating, and there's not always time to
+learn :slightly_smiling_face:
+
+The most accessible ways to get a change made is to reach out to us via:
+
+  * :e-mail: Email:
+    [`hi@civictech.ca`](mailto:hi@civictech.ca?subject=re%3A%20codeacross.ca%20website)
+    (Make sure you mention the codeacross.ca website!)
+  * :bird: Twitter: [@CivicTechTO](twitter.com/civictechto)
+
 <!-- Links -->
    [forking]: https://guides.github.com/activities/forking/
+   [tech-used]: https://github.com/CivicTechTO/codeacross.ca#technologies-used
+   [audience-technical]: #contributing-via-github
+   [audience-no-github]: #contributing-without-github
+   [new-issue]: https://github.com/CivicTechTO/codeacross.ca/issues/new


### PR DESCRIPTION
We no longer make the assumption that someone is comfortable with GitHub just because they're reading this file.

This will open us up to (potentially) link to this document from the website.