### PR TITLE
Update page for 2019

### DIFF
--- a/2018/index.html
+++ b/2018/index.html
@@ -1,5 +1,3 @@
----
----
 <!DOCTYPE html>
 <html>
 
@@ -12,7 +10,7 @@
 
   <title>CodeAcross</title>
 
-  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+  <link rel="stylesheet" href="/assets/css/main.css">
   <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:400,200,900' rel='stylesheet' type='text/css'>
 
   <script>
@@ -38,32 +36,126 @@
 <body>
 
   <section class="header">
-    <img src="{{ '/assets/images/codeacross-logo.svg' | relative_url }}" id="header">
+    <img src="/assets/images/codeacross-logo.svg" id="header">
     <h1>International Open Data Day / Journée internationale de données ouvertes - 2018</h1>
   </section>
 
   <div class="yellow">
-    <img src="{{ '/assets/images/cda_map.gif' | relative_url }}" class="map">
+    <img src="/assets/images/cda_map.gif" class="map">
     <section class="locations">
-      {% assign sorted_provs = site.provinces %}
-      {% assign events_sorted = site.data.events | group_by: "province" %}
-      {% for prov in sorted_provs %}
-        {% assign events_prov = events_sorted | where: "name",prov %}
-        {% assign events_prov = events_prov.first %}
-        {% unless events_prov.size > 0 %}
-          {% continue %}
-        {% else %}
-          {% assign prov_code = events_prov.name %}
-          {% assign events = events_prov.items | sort: 'city' %}
-          <div id="{{prov_code}}" class="location">
-            {% for event in events %}
-              {% assign link = event.url | default: '#' %}
-              <h2><a href="{{ link }}" title="{{ event.name }}"{% unless link == '#' %} target="_blank"{% endunless %}><nobr>{{ event.city }}</nobr></a></h2>
-              <h3><a href="{{ link }}" title="{{ event.name }}"{% unless link == '#' %} target="_blank"{% endunless %}>{{ event.name }}</a></h3>
-            {% endfor %}
+      
+      
+      
+        
+        
+        
+          
+        
+        
+        
+          
+          
+          <div id="BC" class="location">
+            
+              
+              <h2><a href="https://www.meetup.com/OpenDataBC-Vancouver/events/247980407/" title="#VODDay Hackathon" target="_blank"><nobr>Vancouver</nobr></a></h2>
+              <h3><a href="https://www.meetup.com/OpenDataBC-Vancouver/events/247980407/" title="#VODDay Hackathon" target="_blank">#VODDay Hackathon</a></h3>
+            
           </div>
-        {% endunless %}
-      {% endfor %}
+        
+      
+        
+        
+        
+          
+        
+        
+        
+          
+          
+          <div id="AB" class="location">
+            
+              
+              <h2><a href="https://www.eventbrite.ca/e/codeacross-a-civictechyyc-hackathon-tickets-42887965058" title="CodeAcross YYC" target="_blank"><nobr>Calgary</nobr></a></h2>
+              <h3><a href="https://www.eventbrite.ca/e/codeacross-a-civictechyyc-hackathon-tickets-42887965058" title="CodeAcross YYC" target="_blank">CodeAcross YYC</a></h3>
+            
+              
+              <h2><a href="https://www.epl.ca/odd/" title="International Open Data Day 2018" target="_blank"><nobr>Edmonton</nobr></a></h2>
+              <h3><a href="https://www.epl.ca/odd/" title="International Open Data Day 2018" target="_blank">International Open Data Day 2018</a></h3>
+            
+          </div>
+        
+      
+        
+        
+        
+          
+        
+        
+        
+          
+        
+        
+        
+          
+        
+        
+        
+          
+          
+          <div id="ON" class="location">
+            
+              
+              <h2><a href="https://www.eventbrite.ca/e/ottawa-open-data-day-2018-tickets-44614221337" title="Ottawa Open Data Day 2018" target="_blank"><nobr>Ottawa</nobr></a></h2>
+              <h3><a href="https://www.eventbrite.ca/e/ottawa-open-data-day-2018-tickets-44614221337" title="Ottawa Open Data Day 2018" target="_blank">Ottawa Open Data Day 2018</a></h3>
+            
+              
+              <h2><a href="https://www.eventbrite.ca/e/codeacross-toronto-2018-tickets-42848200120" title="CodeAcross Toronto" target="_blank"><nobr>Toronto</nobr></a></h2>
+              <h3><a href="https://www.eventbrite.ca/e/codeacross-toronto-2018-tickets-42848200120" title="CodeAcross Toronto" target="_blank">CodeAcross Toronto</a></h3>
+            
+          </div>
+        
+      
+        
+        
+        
+          
+          
+          <div id="QC" class="location">
+            
+              
+              <h2><a href="http://jido2018.waglo.com/" title="Journée internationale des données ouvertes" target="_blank"><nobr>Montréal</nobr></a></h2>
+              <h3><a href="http://jido2018.waglo.com/" title="Journée internationale des données ouvertes" target="_blank">Journée internationale des données ouvertes</a></h3>
+            
+          </div>
+        
+      
+        
+        
+        
+          
+        
+        
+        
+          
+        
+        
+        
+          
+          
+          <div id="NS" class="location">
+            
+              
+              <h2><a href="https://www.eventbrite.ca/e/nova-scotia-open-data-contest-tickets-42905119367" title="Nova Scotia Open Data Contest" target="_blank"><nobr>Halifax</nobr></a></h2>
+              <h3><a href="https://www.eventbrite.ca/e/nova-scotia-open-data-contest-tickets-42905119367" title="Nova Scotia Open Data Contest" target="_blank">Nova Scotia Open Data Contest</a></h3>
+            
+          </div>
+        
+      
+        
+        
+        
+          
     </section>
   </div>
 
@@ -71,7 +163,7 @@
     <p>On March 3rd 2018, communities across Canada are organizing events about using open data and civic tech for positive impact. Get involved!</p>
     <p>For global event listings, visit <a href="http://opendataday.org">Open Data Day</a>.</p>
     <p>&nbsp;</p>
-    <p>Previous years' events: <a href="{{ '/2016' | relative_url }}">2016</a> <a href="{{ '/2017' | relative_url }}">2017</a></p>
+    <p>Previous years' events: <a href="/2016">2016</a> <a href="/2017">2017</a></p>
     <p>&nbsp;</p>
     <p>This site was originally created by <a href="https://github.com/adriannehlee">Adrianne H Lee</a> and <a href="http://codefor.ca">Code for Canada</a>.
     It is now maintained by <a href="https://github.com/CivicTechTO/codeacross.ca/graphs/contributors">contributors</a> from the civic tech community.</p>

--- a/2018/index.html
+++ b/2018/index.html
@@ -1,0 +1,82 @@
+---
+---
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta name="description" content="CodeAcross and Open Data Day are civic hacking events hosted around the world. Here's a list of the events happening in Canada.">
+  <meta name="author" content="Adrianne H Lee, Urban+Digital" />
+  <meta name="keywords" content="Code, CodeAcross, Across, Canada, hackathon, Vancouver, Edmonton, Calgary, Toronto, Montreal, Halifax, 2018, Open Data Day, ODD" />
+
+  <title>CodeAcross</title>
+
+  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+  <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:400,200,900' rel='stylesheet' type='text/css'>
+
+  <script>
+    (function(i, s, o, g, r, a, m) {
+      i['GoogleAnalyticsObject'] = r;
+      i[r] = i[r] || function() {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date();
+      a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0];
+      a.async = 1;
+      a.src = g;
+      m.parentNode.insertBefore(a, m)
+    })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+
+    ga('create', 'UA-69384890-2', 'auto');
+    ga('send', 'pageview');
+  </script>
+
+</head>
+
+
+<body>
+
+  <section class="header">
+    <img src="{{ '/assets/images/codeacross-logo.svg' | relative_url }}" id="header">
+    <h1>International Open Data Day / Journée internationale de données ouvertes - 2018</h1>
+  </section>
+
+  <div class="yellow">
+    <img src="{{ '/assets/images/cda_map.gif' | relative_url }}" class="map">
+    <section class="locations">
+      {% assign sorted_provs = site.provinces %}
+      {% assign events_sorted = site.data.events | group_by: "province" %}
+      {% for prov in sorted_provs %}
+        {% assign events_prov = events_sorted | where: "name",prov %}
+        {% assign events_prov = events_prov.first %}
+        {% unless events_prov.size > 0 %}
+          {% continue %}
+        {% else %}
+          {% assign prov_code = events_prov.name %}
+          {% assign events = events_prov.items | sort: 'city' %}
+          <div id="{{prov_code}}" class="location">
+            {% for event in events %}
+              {% assign link = event.url | default: '#' %}
+              <h2><a href="{{ link }}" title="{{ event.name }}"{% unless link == '#' %} target="_blank"{% endunless %}><nobr>{{ event.city }}</nobr></a></h2>
+              <h3><a href="{{ link }}" title="{{ event.name }}"{% unless link == '#' %} target="_blank"{% endunless %}>{{ event.name }}</a></h3>
+            {% endfor %}
+          </div>
+        {% endunless %}
+      {% endfor %}
+    </section>
+  </div>
+
+  <div class="description">
+    <p>On March 3rd 2018, communities across Canada are organizing events about using open data and civic tech for positive impact. Get involved!</p>
+    <p>For global event listings, visit <a href="http://opendataday.org">Open Data Day</a>.</p>
+    <p>&nbsp;</p>
+    <p>Previous years' events: <a href="{{ '/2016' | relative_url }}">2016</a> <a href="{{ '/2017' | relative_url }}">2017</a></p>
+    <p>&nbsp;</p>
+    <p>This site was originally created by <a href="https://github.com/adriannehlee">Adrianne H Lee</a> and <a href="http://codefor.ca">Code for Canada</a>.
+    It is now maintained by <a href="https://github.com/CivicTechTO/codeacross.ca/graphs/contributors">contributors</a> from the civic tech community.</p>
+  </div>
+
+</body>
+
+</html>

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -1,37 +1,22 @@
 # NOTE for Ontarians: quotes required for Ontario abbreviation of "ON",
 # otherwise YAML spec determines it to be boolean type "true" (ie. on/off)
 
-- name: CodeAcross YYC
-  url: https://www.eventbrite.ca/e/codeacross-a-civictechyyc-hackathon-tickets-42887965058
-  province: 'AB'
-  city: Calgary
-
 - name: CodeAcross Toronto
   city: Toronto
   province: 'ON'
-  url: https://www.eventbrite.ca/e/codeacross-toronto-2018-tickets-42848200120
+  url: https://www.eventbrite.ca/e/codeacrossto-2019-tickets-53330824933
 
-- name: '#VODDay Hackathon'
-  city: Vancouver
-  province: 'BC'
-  url: https://www.meetup.com/OpenDataBC-Vancouver/events/247980407/
+- name: Winnipeg Open Data Hackathon
+  city: Winnipeg
+  province: 'MB'
+  url: https://www.meetup.com/2019-Winnipeg-Open-Data-Hackathon/events/258525871/
 
-- name: 'Journée internationale des données ouvertes'
-  city: Montréal
-  province: 'QC'
-  url: http://jido2018.waglo.com/
-
-- name: 'Nova Scotia Open Data Contest'
-  city: Halifax
-  province: 'NS'
-  url: https://www.eventbrite.ca/e/nova-scotia-open-data-contest-tickets-42905119367
-
-- name: 'International Open Data Day 2018'
+- name: International Open Data Day
   city: Edmonton
   province: 'AB'
   url: https://www.epl.ca/odd/
-  
-- name: 'Ottawa Open Data Day 2018'
-  city: Ottawa
-  province: 'ON'
-  url: https://www.eventbrite.ca/e/ottawa-open-data-day-2018-tickets-44614221337
+
+- name: Nova Scotia Open Data Contest
+  city: Nova Scotia
+  province: 'NS'
+  url: https://www.eventbrite.ca/e/nova-scotia-open-data-contest-tickets-55411079029

--- a/_data/schedule.csv
+++ b/_data/schedule.csv
@@ -1,0 +1,14 @@
+time,session
+08:00 – 08:30,Registration
+08:30 – 09:00,Opening Remarks
+09:00 – 09:45,Keynote(s)
+09:45 – 10:15,Challenger Pitches
+10:20 – 10:30,Session 0: Icebreakers & Intros
+10:30 – 11:30,Session 1: Mapping Our Community’s Needs
+11:30 – 12:30,Session 2: Sharing Through Technology
+12:30 – 13:15,Lunch
+13:15 – 15:30,Session 3: Building a Solution
+15:30 – 16:00,Session 4: Building a Presentation
+16:00 – 17:00,Presentations
+17:00 – 17:15,Wrap
+18:00 – 21:00,Post–event Social (Location TBD)

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -60,7 +60,7 @@ are based on 10px sizing. So basically 1.5rem = 15px :) */
 html {
   font-size: 62.5%; }
 body {
-  font-size: 1.5em; /* currently ems cause chrome bug misinterpreting rems on body element */
+  font-size: 2em; /* currently ems cause chrome bug misinterpreting rems on body element */
   line-height: 1.6;
   font-family: "Source Sans Pro", Helvetica, Arial, sans-serif;
   font-weight: 400; }
@@ -71,6 +71,30 @@ body {
 
 body {
     margin: auto;
+}
+
+table {
+    margin: 0 auto;
+}
+
+table td, table th {
+    padding: 2px 5px;
+}
+
+table th {
+    text-align: center;
+}
+
+table td {
+    text-align: left;
+}
+
+tbody tr:nth-child(odd) {
+  background-color: #DCDCDC;
+}
+
+tbody tr:nth-child(even) {
+  background-color: white;
 }
 
 .header {
@@ -112,7 +136,7 @@ body {
     position: relative;
     max-width: 1300px;
     margin: auto;
-		text-align: right;
+    text-align: right;
 }
 
 .location {
@@ -131,10 +155,11 @@ body {
     padding-right: 9%;
     margin-bottom: 5rem;
     margin-top: 6rem;
+    text-align: center;
 }
 
 .yellow {
-    padding-top: 25rem;
+    padding-top: 10rem;
     position: relative;
     background-color: #FFDB47;
     background: #FFDB47; /* For browsers that do not support gradients */
@@ -213,6 +238,7 @@ h2 {
     line-height: 0;
     font-weight: 900;
     text-decoration: underline 1px;
+    padding-top: 25px;
 }
 
 h3 {
@@ -220,6 +246,13 @@ h3 {
     line-height: 1;
     font-weight: 200;
     padding-bottom: 1.5rem;
+}
+
+h4 {
+    font-size: 3rem;
+    line-height: 1.5;
+    margin-top: 1rem;
+    font-weight: bold;
 }
 
 
@@ -242,6 +275,10 @@ a {
     color: initial;
 }
 
+b {
+    font-weight: bold;
+}
+
 .description a:hover {
     color: #DA4167;
 }
@@ -256,6 +293,10 @@ a {
 
 img#header {
   margin-top: 10px;
+}
+
+#brief {
+    text-align: left;
 }
 
 /*

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
 
   <section class="header">
     <img src="{{ '/assets/images/codeacross-logo.svg' | relative_url }}" id="header">
-    <h1>International Open Data Day / Journée internationale de données ouvertes - 2018</h1>
+    <h1>International Open Data Day / Journée internationale de données ouvertes - 2019</h1>
   </section>
 
   <div class="yellow">
@@ -68,10 +68,37 @@
   </div>
 
   <div class="description">
-    <p>On March 3rd 2018, communities across Canada are organizing events about using open data and civic tech for positive impact. Get involved!</p>
+    <p>On March 2nd 2019, communities across Canada are organizing events about using open data and civic tech for positive impact. Get involved!</p>
     <p>For global event listings, visit <a href="http://opendataday.org">Open Data Day</a>.</p>
     <p>&nbsp;</p>
-    <p>Previous years' events: <a href="{{ '/2016' | relative_url }}">2016</a> <a href="{{ '/2017' | relative_url }}">2017</a></p>
+    <h4>CodeAcross Toronto Details</h4>
+    <p><b>Date</b><br/>
+    Saturday, March 2 2019</p>
+    <p><b>Location</b><br/>
+    Artscape Daniels Launchpad<br/>
+    130 Queens Quay East<br/>
+    East Tower, 4th Floor<br/>
+    Toronto, Ontario M5A 0P6</p>
+    <p><iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d5774.34916073652!2d-79.36879!3d43.644536!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x15a454c93cfd944b!2sArtscape+Daniels+Launchpad!5e0!3m2!1sen!2sca!4v1549506924583" width="400" height="300" frameborder="0" style="border:0" allowfullscreen></iframe></p>
+
+    <h4>Event Brief</h4>
+    <div id="brief">
+      <p>This year’s CodeAcross will focus on building community resilience for the long-term. How do we help each other make good judgment? How do we build on what we already have? How do we move from some building solutions “for” others to “us” building solutions for ourselves?</p>
+      <p>Just as importantly, the event will be designed to reflect these questions. As a community, we wish to move away from an unnecessary focus on quick fixes and competitive prizes. Technology is not an end solution, but a means to an end. We plan for an event which can help participants of all backgrounds reach a common understanding on the human depth and breadth of our community challenges as the basis for the solutions we build.</p>
+      <p>The event will be accessible and youth-friendly. We intend for the hackathon to be a pop-up public process incubator: to seed connections for collaborators to continue building long after the event is done.</p>
+    </div>
+
+    <h4>Schedule of Events</h4>
+    <p>
+      <table>
+        <tr><th><b>Time</b></th><th><b>Session</b></th></tr>
+        {% for schedule in site.data.schedule %}
+          <tr><td>{{ schedule.time }}</td><td>{{ schedule.session }}</td></tr>
+        {% endfor %}
+      </table>
+    </p>
+    <p>&nbsp;</p>
+    <p>Previous years' events: <a href="{{ '/2016' | relative_url }}">2016</a> <a href="{{ '/2017' | relative_url }}">2017</a> <a href="{{ '/2018' | relative_url }}">2018</a></p>
     <p>&nbsp;</p>
     <p>This site was originally created by <a href="https://github.com/adriannehlee">Adrianne H Lee</a> and <a href="http://codefor.ca">Code for Canada</a>.
     It is now maintained by <a href="https://github.com/CivicTechTO/codeacross.ca/graphs/contributors">contributors</a> from the civic tech community.</p>


### PR DESCRIPTION
2018 page archived.
Events updated with 2019 Canadian events listed on the Open Data Day site.
Added more details about current year's event.