### PR TITLE
Update Toronto link

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -4,7 +4,7 @@
 - name: CodeAcross Toronto
   city: Toronto
   province: 'ON'
-  url: https://www.eventbrite.ca/e/codeacrossto-2019-tickets-53330824933
+  url: http://civictech.ca/codeacross-toronto-2019/
 
 - name: Winnipeg Open Data Hackathon
   city: Winnipeg


### PR DESCRIPTION
Use the civictech.ca website page instead of eventbrite on codeacross.ca